### PR TITLE
Fix incorrect label text on "Open Loadout Button"

### DIFF
--- a/resource/ui/econ/itempickuppanel.res
+++ b/resource/ui/econ/itempickuppanel.res
@@ -302,7 +302,7 @@
 		"pinCorner"									"2"
 		"visible"									"1"
 		"enabled"									"1"
-		"labelText"									"Open Backpack"
+		"labelText"									"%loadouttext%"
 		"font"										"Light 12"
 		"textAlignment"								"center"
 		"Command"									"changeloadout"


### PR DESCRIPTION
Before:

![20221010161412_1](https://user-images.githubusercontent.com/20525615/194875677-32528b72-f296-448f-bdf5-4acee2c7b91d.jpg)

After:

![20221010154559_1](https://user-images.githubusercontent.com/20525615/194875685-90e3097b-5ca9-4654-b65d-603736da9209.jpg)
